### PR TITLE
improve js emits files reading with a dist folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 .vscode
+dist/

--- a/misc/ambient-modules/1-definitely-typed/package.json
+++ b/misc/ambient-modules/1-definitely-typed/package.json
@@ -1,5 +1,5 @@
 {
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json --outDir dist"
   }
 }

--- a/misc/ambient-modules/2-typeRoots/package.json
+++ b/misc/ambient-modules/2-typeRoots/package.json
@@ -1,5 +1,5 @@
 {
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json --outDir dist"
   }
 }

--- a/moduleResolution/Node/1-relative/package.json
+++ b/moduleResolution/Node/1-relative/package.json
@@ -1,5 +1,5 @@
 {
   "scripts": {
-    "build": "npx tsc -p tsconfig.json"
+    "build": "npx tsc -p tsconfig.json --outDir dist"
   }
 }

--- a/moduleResolution/Node/2-non-relative/package.json
+++ b/moduleResolution/Node/2-non-relative/package.json
@@ -1,5 +1,5 @@
 {
   "scripts": {
-    "build": "npx tsc -p tsconfig.json"
+    "build": "npx tsc -p tsconfig.json --outDir dist"
   }
 }

--- a/moduleResolution/Node/3-package/package.json
+++ b/moduleResolution/Node/3-package/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "build1": "npx tsc -p tsconfig1.json",
-    "build2": "npx tsc -p tsconfig2.json"
+    "build1": "npx tsc -p tsconfig1.json --outDir dist",
+    "build2": "npx tsc -p tsconfig2.json --outDir dist"
   }
 }

--- a/moduleResolution/Node/4-index/package.json
+++ b/moduleResolution/Node/4-index/package.json
@@ -1,5 +1,5 @@
 {
   "scripts": {
-    "build": "npx tsc -p tsconfig.json"
+    "build": "npx tsc -p tsconfig.json --outDir dist"
   }
 }

--- a/moduleResolution/Node/5-javascript/package.json
+++ b/moduleResolution/Node/5-javascript/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "build": "npx tsc -p tsconfig.json",
-    "build-allowjs": "npx tsc -p tsconfig-allowjs.json"
+    "build": "npx tsc -p tsconfig.json --outDir dist",
+    "build-allowjs": "npx tsc -p tsconfig-allowjs.json --outDir dist"
   }
 }

--- a/moduleResolution/Node/6-mixed-ts-js/package.json
+++ b/moduleResolution/Node/6-mixed-ts-js/package.json
@@ -1,5 +1,5 @@
 {
   "scripts": {
-    "build": "npx tsc -p tsconfig.json"
+    "build": "npx tsc -p tsconfig.json --outDir dist"
   }
 }

--- a/moduleResolution/Node/7-typesVersions/package.json
+++ b/moduleResolution/Node/7-typesVersions/package.json
@@ -1,5 +1,5 @@
 {
   "scripts": {
-    "build": "npx tsc -p tsconfig.json"
+    "build": "npx tsc -p tsconfig.json --outDir dist"
   }
 }

--- a/moduleResolution/Node16/1-relative/package.json
+++ b/moduleResolution/Node16/1-relative/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "build-cjs": "tsc -p tsconfig-cjs.json",
-    "build-esm": "tsc -p tsconfig-esm.json",
-    "build-extensionless": "tsc -p tsconfig-extensionless.json"
+    "build-cjs": "tsc -p tsconfig-cjs.json --outDir dist",
+    "build-esm": "tsc -p tsconfig-esm.json --outDir dist",
+    "build-extensionless": "tsc -p tsconfig-extensionless.json --outDir dist"
   }
 }

--- a/moduleResolution/Node16/2-export-map/example1-static/package.json
+++ b/moduleResolution/Node16/2-export-map/example1-static/package.json
@@ -1,5 +1,5 @@
 {
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json --outDir dist"
   }
 }

--- a/moduleResolution/Node16/2-export-map/example2-dynamic/package.json
+++ b/moduleResolution/Node16/2-export-map/example2-dynamic/package.json
@@ -1,5 +1,5 @@
 {
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json --outDir dist"
   }
 }

--- a/moduleResolution/Node16/2-export-map/example3-mixed/package.json
+++ b/moduleResolution/Node16/2-export-map/example3-mixed/package.json
@@ -1,5 +1,5 @@
 {
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json --outDir dist"
   }
 }


### PR DESCRIPTION
when you run `npm run build...` the outputs are generated along with other files, 

Then I added  ` --outDir dist ` to each packaga.json file to improve code reading that was generated.

![image](https://github.com/user-attachments/assets/b10a86b7-4a76-421a-8857-4ad7d492b9ac)
